### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mediawiki-fetch.yml
+++ b/.github/workflows/mediawiki-fetch.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 20 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   post:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/minecraft-japan-wiki/wiki-sandbox/security/code-scanning/1](https://github.com/minecraft-japan-wiki/wiki-sandbox/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow does not appear to require write access to the repository, the `contents` permission can be set to `read`. This ensures that the `GITHUB_TOKEN` has restricted access, mitigating potential security risks.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `post` job if other jobs are added later that require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
